### PR TITLE
feat: add a required input "go-version"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ on:
       aqua_version:
         required: true
         type: string
+      go-version:
+        required: true
+        type: string
     secrets:
       gh_app_id:
         required: false
@@ -37,7 +40,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.5"
+          go-version: ${{inputs.go-version}}
           cache: true
 
       - uses: aquaproj/aqua-installer@61e2563dfe7674cbf74fe6ec212e444198a3bb00 # v2.0.2

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ jobs:
     with:
       homebrew: true
       aqua_version: v1.32.3
+      go-version: 1.19.5
     secrets:
       gh_app_id: ${{ secrets.APP_ID }}
       gh_app_private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
BREAKING CHANGE: an input "go-version" is required