### PR TITLE
feat: create GitHub Artifact Attestations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,8 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write # required to create a release
-      id-token: write # required for cosign
+      id-token: write # required for cosign and GitHub Artifact Attestations
+      attestations: write # required for GitHub Artifact Attestations
     steps:
       - run: |
           echo "::error:: Either go-version or go-version-file must be set."
@@ -106,6 +107,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           WINGET_GITHUB_TOKEN: ${{ secrets.winget_github_token }}
+
+      - uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
 
       - name: Generate hashes
         id: hash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,6 +113,9 @@ jobs:
           subject-path: |
             dist/*.tar.gz
             dist/*.zip
+            dist/*.txt
+            dist/*.pem
+            dist/*.sig
 
       - name: Generate hashes
         id: hash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           WINGET_GITHUB_TOKEN: ${{ secrets.winget_github_token }}
 
-      - uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      - uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         with:
           subject-path: |
             dist/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ jobs:
       contents: write
       id-token: write
       actions: read
+      attestations: write
 ```
 
 ## Requirements


### PR DESCRIPTION
## Features

Create GitHub Artifact Attestations.

https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds

## ⚠️ Breaking Changes

The permission `attestations: write` is required to create attestations.