### PR TITLE
feat: separate jobs for security

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,7 +120,7 @@ jobs:
     permissions:
       contents: write # required to create a release
     steps:
-      - uses: actions/download-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         if: "!contains(github.ref_name, '-')"
         with:
           name: dist
@@ -136,7 +136,7 @@ jobs:
       id-token: write # required for GitHub Artifact Attestations
       attestations: write # required for GitHub Artifact Attestations
     steps:
-      - uses: actions/download-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         if: "!contains(github.ref_name, '-')"
         with:
           name: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,8 +117,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     needs: [build]
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write # required to create a release
     steps:
@@ -134,8 +132,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     needs: [build]
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       id-token: write # required for GitHub Artifact Attestations
       attestations: write # required for GitHub Artifact Attestations
@@ -156,7 +152,7 @@ jobs:
             dist/*.jsonl
 
   provenance:
-    needs: [release]
+    needs: [build, release]
     permissions:
       actions: read # Needed for detection of GitHub Actions environment.
       id-token: write # Needed for provenance signing and ID

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,13 +132,14 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: checksum
+          path: dist
       - run: cosign version
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - run: |
           checksum=$(find dist -name "*checksums.txt")
           cosign sign-blob -y \
-            --output-signature "${checksum}.sig" \
+            --output-signature "dist/${checksum}.sig" \
             --output-certificate "${checksum}.pem" \
             --oidc-provider github \
             "$checksum"
@@ -160,9 +161,11 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
+          path: dist
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: cosign
+          path: dist
       - run: ls dist
       - run: gh release create -R "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" -p dist/*
         env:
@@ -177,12 +180,13 @@ jobs:
       attestations: write # required for GitHub Artifact Attestations
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        if: "!contains(github.ref_name, '-')"
         with:
           name: dist
+          path: dist
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: cosign
+          path: dist
       - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
+        with:
+          aqua_version: ${{inputs.aqua_version}}
+          policy_allow: ${{inputs.aqua_policy_allow}}
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: checksum

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,9 +35,8 @@ jobs:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
-      contents: write # required to create a release
-      id-token: write # required for cosign and GitHub Artifact Attestations
-      attestations: write # required for GitHub Artifact Attestations
+      contents: read
+      id-token: write # required for cosign
     steps:
       - run: |
           echo "::error:: Either go-version or go-version-file must be set."
@@ -80,9 +79,22 @@ jobs:
           curl -Lq -o third_party_licenses/go/LICENSE --retry 5 "https://raw.githubusercontent.com/golang/go/refs/tags/go${version#go}/LICENSE"
 
       - name: Run GoReleaser
-        run: goreleaser release --clean
+        run: goreleaser release --skip publish --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: "!contains(github.ref_name, '-')"
+        with:
+          name: dist
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.txt
+            dist/*.pem
+            dist/*.sig
+            dist/*.sbom.json
+            dist/*.jsonl
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!contains(github.ref_name, '-')"
@@ -93,6 +105,45 @@ jobs:
             dist/scoop
             dist/winget
 
+      - name: Generate hashes
+        id: hash
+        run: |
+          # sha256sum generates sha256 hash for all artifacts.
+          # base64 -w0 encodes to base64 and outputs on a single line.
+          # sha256sum artifact1 artifact2 ... | base64 -w0
+          echo "hashes=$( (find dist -name "*.tar.gz" && find dist -name "*.zip") | xargs sha256sum | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  release:
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    needs: [build]
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: write # required to create a release
+    steps:
+      - uses: actions/download-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: "!contains(github.ref_name, '-')"
+        with:
+          name: dist
+      - run: gh release create "$GITHUB_REF_NAME" -p dist/*
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  attestation:
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    needs: [build]
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      id-token: write # required for GitHub Artifact Attestations
+      attestations: write # required for GitHub Artifact Attestations
+    steps:
+      - uses: actions/download-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: "!contains(github.ref_name, '-')"
+        with:
+          name: dist
       - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
@@ -102,17 +153,10 @@ jobs:
             dist/*.pem
             dist/*.sig
             dist/*.sbom.json
-
-      - name: Generate hashes
-        id: hash
-        run: |
-          # sha256sum generates sha256 hash for all artifacts.
-          # base64 -w0 encodes to base64 and outputs on a single line.
-          # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$( (find dist -name "*.tar.gz" && find dist -name "*.zip") | xargs sha256sum | base64 -w0)" >> "$GITHUB_OUTPUT"
+            dist/*.jsonl
 
   provenance:
-    needs: [build]
+    needs: [release]
     permissions:
       actions: read # Needed for detection of GitHub Actions environment.
       id-token: write # Needed for provenance signing and ID

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       - run: |
           checksum=$(find dist -name "*checksums.txt")
           cosign sign-blob -y \
-            --output-signature "dist/${checksum}.sig" \
+            --output-signature "${checksum}.sig" \
             --output-certificate "${checksum}.pem" \
             --oidc-provider github \
             "$checksum"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,20 +84,22 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: "!contains(github.ref_name, '-')"
         with:
           name: dist
           path: |
             dist/*.tar.gz
             dist/*.zip
             dist/*.txt
-            dist/*.pem
-            dist/*.sig
             dist/*.sbom.json
             dist/*.jsonl
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: "!contains(github.ref_name, '-')"
+        with:
+          name: checksum
+          path: |
+            dist/*.txt
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: goreleaser
           path: |
@@ -113,25 +115,59 @@ jobs:
           # sha256sum artifact1 artifact2 ... | base64 -w0
           echo "hashes=$( (find dist -name "*.tar.gz" && find dist -name "*.zip") | xargs sha256sum | base64 -w0)" >> "$GITHUB_OUTPUT"
 
-  release:
+  cosign:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     needs: [build]
     permissions:
+      id-token: write # required for cosign
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: checksum
+      - run: cosign version
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - run: |
+          checksum=$(find dist -name "*checksums.txt")
+          cosign sign-blob -y \
+            --output-signature "${checksum}.sig" \
+            --output-certificate "${checksum}.pem" \
+            --oidc-provider github \
+            "$checksum"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cosign
+          path: |
+            dist/*.pem
+            dist/*.sig
+
+  release:
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    needs: [cosign]
+    permissions:
       contents: write # required to create a release
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        if: "!contains(github.ref_name, '-')"
         with:
           name: dist
-      - run: gh release create "$GITHUB_REF_NAME" -p dist/*
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cosign
+      - run: ls dist
+      - run: gh release create -R "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" -p dist/*
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
   attestation:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    needs: [build]
+    needs: [cosign]
     permissions:
       id-token: write # required for GitHub Artifact Attestations
       attestations: write # required for GitHub Artifact Attestations
@@ -140,6 +176,9 @@ jobs:
         if: "!contains(github.ref_name, '-')"
         with:
           name: dist
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cosign
       - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
@@ -149,7 +188,6 @@ jobs:
             dist/*.pem
             dist/*.sig
             dist/*.sbom.json
-            dist/*.jsonl
 
   provenance:
     needs: [build, release]


### PR DESCRIPTION
This pr split the job `build` to `build`, `cosign`, `release`, and `attestation` for security.

https://slsa.dev/spec/v1.1/requirements

> - Any secret material used for authenticating the provenance, for example the signing key used to generate a digital signature, MUST be stored in a secure management system appropriate for such material and accessible only to the build service account.
> - Such secret material MUST NOT be accessible to the environment running the user-defined build steps.

> - It MUST NOT be possible for a build to access any secrets of the build platform, such as the provenance signing key, because doing so would compromise the authenticity of the provenance.

https://slsa.dev/spec/v1.1/threats

> Steal cryptographic secrets (Build L3)
> Threat: Use or exfiltrate the provenance signing key or some other cryptographic secret that should only be available to the build platform.
> Mitigation: Builds are [isolated](https://slsa.dev/spec/v1.1/requirements#isolated) from the trusted build platform control plane, and only the control plane has [access](https://slsa.dev/spec/v1.1/requirements#provenance-unforgeable) to cryptographic secrets.
> Example: Provenance is signed on the build worker, which the adversary has control over. Adversary uses a malicious process that generates false provenance and signs it using the provenance signing key. Solution: Builder generates and signs provenance in the trusted control plane; the worker has no access to the key.

> Forge values of the provenance (other than output digest)
> Example 2 (Build L3): Provenance is generated in the trusted control plane, but workers can break out of the container to access the signing material. Solution: Builder is hardened to provide strong isolation against tenant projects.

## ⚠️ Breaking Changes

You must stop running Cosign by GoReleaser.
Please remove the following code from .goreleaser.yaml.

```yaml
signs:
  - cmd: cosign
    artifacts: checksum
    signature: ${artifact}.sig
    certificate: ${artifact}.pem
    output: true
    args:
      - sign-blob
      - "-y"
      - --output-signature
      - ${signature}
      - --output-certificate
      - ${certificate}
      - --oidc-provider
      - github
      - ${artifact}
```